### PR TITLE
Add compat to popular storage mods & Quark

### DIFF
--- a/src/main/resources/data/civil/civil_blocks/compat_ae2.json
+++ b/src/main/resources/data/civil/civil_blocks/compat_ae2.json
@@ -1,0 +1,35 @@
+{
+  "_comment": [
+    "Civil mod compatibility: Applied Energistics 2 (ae2).",
+    "Block IDs verified against Ae2 namespace entries 1.20.1.",
+    "If the mod is not installed, these entries are safely ignored."
+  ],
+  "replace": false,
+  "entries": [
+    { "block": "ae2:controller",                       "weight": 1.5 },
+
+    { "block": "ae2:charger",                          "weight": 0.5 },
+    { "block": "ae2:inscriber",                        "weight": 0.5 },
+    { "block": "ae2:cell_workbench",                   "weight": 0.5 },
+
+    { "block": "ae2:molecular_assembler",              "weight": 0.4 },
+    { "block": "ae2:crystal_resonance_generator",      "weight": 0.4 },
+    { "block": "ae2:io_port",                          "weight": 0.4 },
+    { "block": "ae2:interface",                        "weight": 0.4 },
+    { "block": "ae2:vibration_chamber",                "weight": 0.4 },
+
+    { "block": "ae2:sky_stone_chest",                  "weight": 0.3 },
+    { "block": "ae2:smooth_sky_stone_chest",           "weight": 0.3 },
+    { "block": "ae2:drive",                            "weight": 0.3 },
+    { "block": "ae2:chest",                            "weight": 0.3 },
+    { "block": "ae2:energy_cell",                      "weight": 0.3 },
+    { "block": "ae2:dense_energy_cell",                "weight": 0.3 },
+    { "block": "ae2:crafting_monitor",                 "weight": 0.3 },
+    { "block": "ae2:pattern_provider",                 "weight": 0.3 },
+    { "block": "ae2:crafting_unit",                    "weight": 0.3 },
+    { "block": "ae2:crafting_accelerator",             "weight": 0.3 },
+
+    { "block": "ae2:sky_stone_tank",                   "weight": 0.1 },
+    { "block": "ae2:growth_accelerator",               "weight": 0.1 }
+  ]
+}

--- a/src/main/resources/data/civil/civil_blocks/compat_drawers.json
+++ b/src/main/resources/data/civil/civil_blocks/compat_drawers.json
@@ -1,0 +1,17 @@
+{
+  "_comment": [
+    "Civil mod compatibility: Storage Drawers (storagedrawers).",
+    "Block IDs verified against Storage Drawers namespace entries 1.20.1.",
+    "If the mod is not installed, these entries are safely ignored."
+  ],
+  "replace": false,
+  "entries": [
+    { "block": "storagedrawers:controller",                 "weight": 0.5 },
+    { "block": "storagedrawers:framing_table",              "weight": 0.5 },
+
+    { "block": "storagedrawers:compacting_drawers_2",       "weight": 0.2 },
+    { "block": "storagedrawers:compacting_drawers_3",       "weight": 0.2 },
+    { "block": "storagedrawers:compacting_half_drawers_2",  "weight": 0.2 },
+    { "block": "storagedrawers:compacting_half_drawers_3",  "weight": 0.2 }
+  ]
+}

--- a/src/main/resources/data/civil/civil_blocks/compat_functionalstorage.json
+++ b/src/main/resources/data/civil/civil_blocks/compat_functionalstorage.json
@@ -1,0 +1,17 @@
+{
+  "_comment": [
+    "Civil mod compatibility: Functional Storage (functionalstorage).",
+    "Block IDs verified against Storage Drawers namespace entries 1.20.1.",
+    "If the mod is not installed, these entries are safely ignored."
+  ],
+  "replace": false,
+  "entries": [
+    { "block": "functionalstorage:storage_controller",        "weight": 0.5 },
+    { "block": "functionalstorage:controller_extension",      "weight": 0.4 },
+
+    { "block": "functionalstorage:compacting_drawer",         "weight": 0.2 },
+    { "block": "functionalstorage:simple_compacting_drawer",  "weight": 0.2 },
+    { "block": "functionalstorage:armory_cabinet",            "weight": 0.2 },
+    { "block": "functionalstorage:ender_drawer",              "weight": 0.2 }
+  ]
+}

--- a/src/main/resources/data/civil/civil_blocks/compat_ironchests.json
+++ b/src/main/resources/data/civil/civil_blocks/compat_ironchests.json
@@ -1,0 +1,16 @@
+{
+  "_comment": [
+    "Civil mod compatibility: Iron Chests (ironchest).",
+    "Block IDs verified against Iron Chests namespace entries 1.20.1.",
+    "If the mod is not installed, these entries are safely ignored."
+  ],
+  "replace": false,
+  "entries": [
+    { "block": "ironchest:iron_chest",                "weight": 0.3 },
+    { "block": "ironchest:gold_chest",                "weight": 0.3 },
+    { "block": "ironchest:diamond_chest",             "weight": 0.3 },
+    { "block": "ironchest:copper_chest",              "weight": 0.3 },
+    { "block": "ironchest:crystal_chest",             "weight": 0.3 },
+    { "block": "ironchest:obsidian_chest",            "weight": 0.3 }
+  ]
+}

--- a/src/main/resources/data/civil/civil_blocks/compat_quark.json
+++ b/src/main/resources/data/civil/civil_blocks/compat_quark.json
@@ -1,0 +1,35 @@
+{
+  "_comment": [
+    "Civil mod compatibility: Quark (quark).",
+    "Block IDs verified against Quark namespace entries 1.20.1.",
+    "If the mod is not installed, these entries are safely ignored."
+  ],
+  "replace": false,
+  "entries": [
+    { "block": "quark:matrix_enchanter",               "weight": 1.5 },
+
+    { "block": "quark:ender_watcher",                  "weight": 0.7 },
+
+    { "block": "quark:deepslate_furnace",              "weight": 0.3 },
+    { "block": "quark:blackstone_furnace",             "weight": 0.3 },
+    { "block": "quark:crafter",                        "weight": 0.3 },
+    { "block": "quark:crate",                          "weight": 0.3 },
+    { "block": "quark:magnet",                         "weight": 0.3 },
+    { "block": "quark:ancient_chest",                  "weight": 0.3 },
+    { "block": "quark:prismarine_chest",               "weight": 0.3 },
+    { "block": "quark:acacia_chest",                   "weight": 0.3 },
+    { "block": "quark:dark_oak_chest",                 "weight": 0.3 },
+    { "block": "quark:crimson_chest",                  "weight": 0.3 },
+    { "block": "quark:warped_chest",                   "weight": 0.3 },
+    { "block": "quark:bamboo_chest",                   "weight": 0.3 },
+    { "block": "quark:mangrove_chest",                 "weight": 0.3 },
+    { "block": "quark:cherry_chest",                   "weight": 0.3 },
+    { "block": "quark:nether_brick_chest",             "weight": 0.3 },
+    { "block": "quark:purpur_chest",                   "weight": 0.3 },
+    { "block": "quark:blossom_chest",                  "weight": 0.3 },
+    { "block": "quark:azalea_chest",                   "weight": 0.3 },
+    { "block": "quark:oak_chest",                      "weight": 0.3 },
+    { "block": "quark:spruce_chest",                   "weight": 0.3 },
+    { "block": "quark:jungle_chest",                   "weight": 0.3 }
+  ]
+}

--- a/src/main/resources/data/civil/civil_blocks/compat_sophisticatedstorage.json
+++ b/src/main/resources/data/civil/civil_blocks/compat_sophisticatedstorage.json
@@ -1,0 +1,26 @@
+{
+  "_comment": [
+    "Civil mod compatibility: Sophisticated Storage (sophisticatedstorage).",
+    "Block IDs verified against Sophisticated Storage namespace entries 1.20.1.",
+    "If the mod is not installed, these entries are safely ignored."
+  ],
+  "replace": false,
+  "entries": [
+    { "block": "sophisticatedstorage:decoration_table",            "weight": 0.5 },
+
+    { "block": "sophisticatedstorage:controller",                  "weight": 0.5 },
+
+    { "block": "sophisticatedstorage:storage_link",                "weight": 0.3 },
+    { "block": "sophisticatedstorage:copper_barrel",               "weight": 0.3 },
+    { "block": "sophisticatedstorage:iron_barrel",                 "weight": 0.3 },
+    { "block": "sophisticatedstorage:gold_barrel",                 "weight": 0.3 },
+    { "block": "sophisticatedstorage:diamond_barrel",              "weight": 0.3 },
+    { "block": "sophisticatedstorage:netherite_barrel",            "weight": 0.3 },
+    { "block": "sophisticatedstorage:chest",                       "weight": 0.3 },
+    { "block": "sophisticatedstorage:copper_chest",                "weight": 0.3 },
+    { "block": "sophisticatedstorage:iron_chest",                  "weight": 0.3 },
+    { "block": "sophisticatedstorage:gold_chest",                  "weight": 0.3 },
+    { "block": "sophisticatedstorage:diamond_chest",               "weight": 0.3 },
+    { "block": "sophisticatedstorage:netherite_chest",             "weight": 0.3 }
+  ]
+}


### PR DESCRIPTION
Adds compatibility with the following mods into base Civilis :
- Quark
- Applied Energetics 2
- Storage Drawers
- Functional Storage
- Iron Chests
- Sophisticated Storage

These mods are popular, frequently used and would benefit from being included in base default Civilis.