### PR TITLE
Add compatibility to structure & dimension mods

### DIFF
--- a/src/main/resources/data/civil/civil_dimension_policies/dimmods.json
+++ b/src/main/resources/data/civil/civil_dimension_policies/dimmods.json
@@ -14,14 +14,9 @@
   ],
   "replace": false,
   "entries": [
-    { "dimension": "minecells:prison", "civilization": false },
-    { "dimension": "minecells:promenade", "civilization": false },
-    { "dimension": "minecells:insufferable_crypt", "civilization": false },
-    { "dimension": "minecells:black_bridge", "civilization": false },
-    { "dimension": "minecells:ramparts", "civilization": false },
-    { "dimension": "dimdungeons:dungeon_dimension", "civilization": false },
-    { "dimension": "dimdungeons:build_dimension", "civilization": false },
+    { "dimension": "blood_magic:dungeon", "civilization": false },
     { "dimension": "the_deep_void:deep_void", "civilization": false },
+    { "dimension": "the_deep_void:the_pit", "civilization": false },
     { "dimension": "perdition:purgatory", "civilization": false },
     { "dimension": "perdition:dis", "civilization": false }
   ]

--- a/src/main/resources/data/civil/civil_zone_policies/ati.json
+++ b/src/main/resources/data/civil/civil_zone_policies/ati.json
@@ -1,0 +1,52 @@
+{
+  "replace": false,
+  "entries": [
+    {
+      "id": "ati_structures_all",
+      "structures": [
+        "ati_structures:ancient_temple",
+        "ati_structures:ancient_vessel",
+        "ati_structures:arachnid_dwelling",
+        "ati_structures:ati_stoneworks",
+        "ati_structures:castillo",
+        "ati_structures:catalonian_castle",
+        "ati_structures:dark_keep",
+        "ati_structures:dark_tower",
+        "ati_structures:deepslate_keep",
+        "ati_structures:desert_outpost",
+        "ati_structures:dojo",
+        "ati_structures:fortified_temple",
+        "ati_structures:gnome_hut",
+        "ati_structures:granite_fort",
+        "ati_structures:haunted_ruin",
+        "ati_structures:herobrine_stronghold",
+        "ati_structures:illager_homestead",
+        "ati_structures:illager_tower",
+        "ati_structures:lighthouse",
+        "ati_structures:jungle_settlement",
+        "ati_structures:manor",
+        "ati_structures:marble_chateau",
+        "ati_structures:monastery_tower",
+        "ati_structures:mosque",
+        "ati_structures:mud_tower",
+        "ati_structures:nomadic_camp",
+        "ati_structures:old_fort",
+        "ati_structures:old_home",
+        "ati_structures:old_residence",
+        "ati_structures:overgrown_outpost",
+        "ati_structures:quarry",
+        "ati_structures:rotting_temple",
+        "ati_structures:ruined_castle",
+        "ati_structures:sinking_temple",
+        "ati_structures:steam_house",
+        "ati_structures:small_keep",
+        "ati_structures:spider_nest",
+        "ati_structures:stray_ruins",
+        "ati_structures:wither_keep"
+      ],
+      "rules": {
+        "allow_hostile_spawn": true
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/civil/civil_zone_policies/borninchaos.json
+++ b/src/main/resources/data/civil/civil_zone_policies/borninchaos.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "entries": [
+    {
+      "id": "born_in_chaos_v1_all",
+      "structures": [
+        "born_in_chaos_v1:clown_caravan_plains",
+        "born_in_chaos_v1:clown_caravan_savanna",
+        "born_in_chaos_v1:clown_caravan_taiga",
+        "born_in_chaos_v1:dark_tower_forest",
+        "born_in_chaos_v1:dark_tower_plain",
+        "born_in_chaos_v1:dark_tower_taiga",
+        "born_in_chaos_v1:farm",
+        "born_in_chaos_v1:firewell",
+        "born_in_chaos_v1:observation_tower_forest",
+        "born_in_chaos_v1:observation_tower_plains"
+      ],
+      "rules": {
+        "allow_hostile_spawn": true
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/civil/civil_zone_policies/hexerei.json
+++ b/src/main/resources/data/civil/civil_zone_policies/hexerei.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "entries": [
+    {
+      "id": "hexerei_all",
+      "structures": [
+        "hexerei:nature_coven",
+        "hexerei:dark_coven"
+      ],
+      "rules": {
+        "allow_hostile_spawn": true
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/civil/civil_zone_policies/ironspells.json
+++ b/src/main/resources/data/civil/civil_zone_policies/ironspells.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "entries": [
+    {
+      "id": "irons_spellbook_all",
+      "structures": [
+        "irons_spellbook:ancient_battleground",
+        "irons_spellbook:catacombs",
+        "irons_spellbook:citadel",
+        "irons_spellbook:evoker_fort",
+        "irons_spellbook:ice_spider_den",
+        "irons_spellbook:impaled_icebreaker",
+        "irons_spellbook:mangrove_hut",
+        "irons_spellbook:mountain_tower",
+        "irons_spellbook:pyromancer_tower",
+        "irons_spellbook:catacombs"
+      ],
+      "rules": {
+        "allow_hostile_spawn": true
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/civil/civil_zone_policies/minecolonies.json
+++ b/src/main/resources/data/civil/civil_zone_policies/minecolonies.json
@@ -1,0 +1,28 @@
+{
+  "replace": false,
+  "entries": [
+    {
+      "id": "minecolonies_all",
+      "structures": [
+        "minecolonies:amazon_camp",
+        "minecolonies:asian_colony",
+        "minecolonies:barbarian_camp",
+        "minecolonies:caledonia_colony",
+        "minecolonies:desert_camp",
+        "minecolonies:desertoasis_colony",
+        "minecolonies:incan_colony",
+        "minecolonies:lostmesacity_colony",
+        "minecolonies:medieval_birch_colony",
+        "minecolonies:medieval_dark_oak_colony",
+        "minecolonies:medieval_oak_colony",
+        "minecolonies:medieval_spruce_colony",
+        "minecolonies:ship",
+        "minecolonies:shire_colony",
+        "minecolonies:warpednetherlands_colony"
+      ],
+      "rules": {
+        "allow_hostile_spawn": true
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/civil/civil_zone_policies/terralith.json
+++ b/src/main/resources/data/civil/civil_zone_policies/terralith.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "entries": [
+    {
+      "id": "terralith_all",
+      "structures": [
+        "terralith:mage_complex",
+        "terralith:mage_tower",
+        "terralith:mage_tower_autumn",
+        "terralith:mage_tower_spring",
+        "terralith:mage_tower_winter",
+        "terralith:mage_tower_summer",
+        "terralith:spire",
+        "terralith:underground/frosted_dungeon",
+        "terralith:underground_cabin",
+        "terralith:witch_hut"
+      ],
+      "rules": {
+        "allow_hostile_spawn": true
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/civil/civil_zone_policies/underground_bunkers.json
+++ b/src/main/resources/data/civil/civil_zone_policies/underground_bunkers.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "entries": [
+    {
+      "id": "underground_bunkers_all",
+      "structures": [
+        "underground_bunkers:underground_bunker"
+      ],
+      "rules": {
+        "allow_hostile_spawn": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds civil zone policies and civil dimension policies to hostile structures and dimensions that should not generate civilized areas.

Adds compatibility for the following structure and dimension mods:
- ATi Structures
- Born In Chaos
- Blood Magic
- Deep Void
- Hexerei
- Irons Spellbooks
- Perdition
- Minecolonies
- Terralith
- Underground Bunkers